### PR TITLE
[squid:ModifiersOrderCheck] Modifiers should be declared in the correct order

### DIFF
--- a/src/main/java/ltistarter/Application.java
+++ b/src/main/java/ltistarter/Application.java
@@ -65,7 +65,7 @@ import javax.annotation.PostConstruct;
 // allows @Secured flag - proxyTargetClass = true causes this to die
 public class Application extends WebMvcConfigurerAdapter {
 
-    final static Logger log = LoggerFactory.getLogger(Application.class);
+    static final Logger log = LoggerFactory.getLogger(Application.class);
 
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);

--- a/src/main/java/ltistarter/config/ApplicationConfig.java
+++ b/src/main/java/ltistarter/config/ApplicationConfig.java
@@ -38,9 +38,9 @@ import javax.annotation.Resource;
 @Component
 public class ApplicationConfig implements ApplicationContextAware {
 
-    final static Logger log = LoggerFactory.getLogger(ApplicationConfig.class);
-    private volatile static ApplicationContext context;
-    private volatile static ApplicationConfig config;
+    static final Logger log = LoggerFactory.getLogger(ApplicationConfig.class);
+    private static volatile ApplicationContext context;
+    private static volatile ApplicationConfig config;
 
     @Autowired
     ConfigurableEnvironment env;

--- a/src/main/java/ltistarter/controllers/BaseController.java
+++ b/src/main/java/ltistarter/controllers/BaseController.java
@@ -29,7 +29,7 @@ import java.util.Date;
  */
 public class BaseController {
 
-    final static Logger log = LoggerFactory.getLogger(BaseController.class);
+    static final Logger log = LoggerFactory.getLogger(BaseController.class);
 
     @Autowired
     @SuppressWarnings("SpringJavaAutowiringInspection")

--- a/src/main/java/ltistarter/database/DatabasePreload.java
+++ b/src/main/java/ltistarter/database/DatabasePreload.java
@@ -38,7 +38,7 @@ import javax.annotation.PostConstruct;
 // only load this when running the application (not for unit tests which have the 'testing' profile active)
 public class DatabasePreload {
 
-    final static Logger log = LoggerFactory.getLogger(DatabasePreload.class);
+    static final Logger log = LoggerFactory.getLogger(DatabasePreload.class);
 
     @Autowired
     ApplicationConfig applicationConfig;

--- a/src/main/java/ltistarter/lti/LTIConsumerDetailsService.java
+++ b/src/main/java/ltistarter/lti/LTIConsumerDetailsService.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class LTIConsumerDetailsService implements ConsumerDetailsService {
 
-    final static Logger log = LoggerFactory.getLogger(LTIConsumerDetailsService.class);
+    static final Logger log = LoggerFactory.getLogger(LTIConsumerDetailsService.class);
 
     @Autowired
     @SuppressWarnings("SpringJavaAutowiringInspection")

--- a/src/main/java/ltistarter/lti/LTIDataService.java
+++ b/src/main/java/ltistarter/lti/LTIDataService.java
@@ -32,7 +32,7 @@ import java.util.List;
 @Component
 public class LTIDataService {
 
-    final static Logger log = LoggerFactory.getLogger(LTIDataService.class);
+    static final Logger log = LoggerFactory.getLogger(LTIDataService.class);
 
     @Autowired
     AllRepositories repos;

--- a/src/main/java/ltistarter/lti/LTIOAuthAuthenticationHandler.java
+++ b/src/main/java/ltistarter/lti/LTIOAuthAuthenticationHandler.java
@@ -36,7 +36,7 @@ import java.util.HashSet;
 @Component
 public class LTIOAuthAuthenticationHandler implements OAuthAuthenticationHandler {
 
-    final static Logger log = LoggerFactory.getLogger(LTIOAuthAuthenticationHandler.class);
+    static final Logger log = LoggerFactory.getLogger(LTIOAuthAuthenticationHandler.class);
 
     public static SimpleGrantedAuthority userGA = new SimpleGrantedAuthority("ROLE_USER");
     public static SimpleGrantedAuthority learnerGA = new SimpleGrantedAuthority("ROLE_LEARNER");

--- a/src/main/java/ltistarter/lti/LTIRequest.java
+++ b/src/main/java/ltistarter/lti/LTIRequest.java
@@ -58,7 +58,7 @@ import java.util.*;
  */
 public class LTIRequest {
 
-    final static Logger log = LoggerFactory.getLogger(LTIRequest.class);
+    static final Logger log = LoggerFactory.getLogger(LTIRequest.class);
 
     static final String LIS_PERSON_PREFIX = "lis_person_name_";
 

--- a/src/main/java/ltistarter/model/LtiMembershipEntity.java
+++ b/src/main/java/ltistarter/model/LtiMembershipEntity.java
@@ -20,8 +20,8 @@ import javax.persistence.*;
 @Table(name = "lti_membership")
 public class LtiMembershipEntity extends BaseEntity {
 
-    public final static int ROLE_STUDENT = 0;
-    public final static int ROLE_INTRUCTOR = 1;
+    public static final int ROLE_STUDENT = 0;
+    public static final int ROLE_INTRUCTOR = 1;
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/ltistarter/oauth/MyConsumerDetailsService.java
+++ b/src/main/java/ltistarter/oauth/MyConsumerDetailsService.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MyConsumerDetailsService implements ConsumerDetailsService {
 
-    final static Logger log = LoggerFactory.getLogger(MyConsumerDetailsService.class);
+    static final Logger log = LoggerFactory.getLogger(MyConsumerDetailsService.class);
 
     @Override
     public ConsumerDetails loadConsumerByConsumerKey(String consumerKey) throws OAuthException {

--- a/src/main/java/ltistarter/oauth/MyOAuthAuthenticationHandler.java
+++ b/src/main/java/ltistarter/oauth/MyOAuthAuthenticationHandler.java
@@ -36,7 +36,7 @@ import java.util.HashSet;
 @Component
 public class MyOAuthAuthenticationHandler implements OAuthAuthenticationHandler {
 
-    final static Logger log = LoggerFactory.getLogger(MyOAuthAuthenticationHandler.class);
+    static final Logger log = LoggerFactory.getLogger(MyOAuthAuthenticationHandler.class);
 
     public static SimpleGrantedAuthority userGA = new SimpleGrantedAuthority("ROLE_USER");
     public static SimpleGrantedAuthority adminGA = new SimpleGrantedAuthority("ROLE_ADMIN");

--- a/src/main/java/ltistarter/oauth/MyOAuthProcessingFilterEntryPointImpl.java
+++ b/src/main/java/ltistarter/oauth/MyOAuthProcessingFilterEntryPointImpl.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 @Component
 public class MyOAuthProcessingFilterEntryPointImpl extends OAuthProcessingFilterEntryPoint {
 
-    final static Logger log = LoggerFactory.getLogger(MyOAuthProcessingFilterEntryPointImpl.class);
+    static final Logger log = LoggerFactory.getLogger(MyOAuthProcessingFilterEntryPointImpl.class);
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {

--- a/src/main/java/ltistarter/oauth/OAuthUtils.java
+++ b/src/main/java/ltistarter/oauth/OAuthUtils.java
@@ -35,7 +35,7 @@ import java.util.Map;
  */
 public class OAuthUtils {
 
-    final static Logger log = LoggerFactory.getLogger(OAuthUtils.class);
+    static final Logger log = LoggerFactory.getLogger(OAuthUtils.class);
 
     public static ResponseEntity sendOAuth1Request(String url, String consumerKey, String sharedSecret, Map<String, String> params, Map<String, String> headers) {
         assert url != null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.
Ayman Abdelghany.
